### PR TITLE
Update App insights to 3.4.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
  # renovate: datasource=github-releases depName=microsoft/ApplicationInsights-Java
-ARG APP_INSIGHTS_AGENT_VERSION=3.2.4
+ARG APP_INSIGHTS_AGENT_VERSION=3.4.11
 ARG PLATFORM=""
 FROM hmctspublic.azurecr.io/base/java:17-distroless
 


### PR DESCRIPTION
### Change description ###
3.4.12 is out but want to see if renovate eventually opens a pr to upgrade. I also want to upgrade now to see if it fixes the deployment



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
