### PR TITLE
DTSPO-17617 - Add value for flexible server sku

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -99,4 +99,5 @@ module "postgresql_flexible" {
   ]
 
   pgsql_version = "15"
+  pgsql_sku = var.pgsql_sku
 }

--- a/infrastructure/sandbox.tfvars
+++ b/infrastructure/sandbox.tfvars
@@ -1,1 +1,2 @@
 api_gateway_test_certificate_thumbprint = "4A98AB1CFFBA46CACBC7D8D3E10FDA667261DFAA"
+pgsql_sku = "B_Standard_B1ms"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -43,3 +43,7 @@ variable "private_dns_subscription_id" {
 variable "common_tags" {
   type = map(string)
 }
+
+variable "pgsql_sku" {
+  default = "GP_Standard_D2s_v3"
+}


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-17617

### Change description

Changing sandbox to use the burstable sku
This is to test whether this will work for toffee so we can have sandbox start up automatically every morning.
This will reduce cost and keep pipelines working that rely on plum sandbox being reachable.
Has been tested with plum as well and it seems to be working ok so far

### Testing done

The website seems to still load after the change in SKU.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
