### PR TITLE
Adding conditional logic to create_mode for psql flex

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -88,7 +88,7 @@ module "postgresql_flexible" {
   component     = var.component
   business_area = "sds"
   location      = var.location
-  create_mode   = "Update"
+  create_mode   = var.env == "sbox" ? "Default" : "Update"
 
   common_tags          = var.common_tags
   admin_user_object_id = var.jenkins_AAD_objectId


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-24310

### Change description

- Adding conditional logic to create_mode in the postgresql_flexible module to change the value to "Default" for sbox.
- This is needed as create_mode cannot be set to "Update" during creation as stated in the [docs](https://registry.terraform.io/providers/hashicorp/azurerm/4.21.0/docs/resources/postgresql_flexible_server).
- The sbox postgresql database has been deleted and needs recreated as it is blocking checks on PRs. 
- If the env is set to "sbox", create_mode will be set to "Default". For all other envs, it will remain as "Update".

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
