### PR TITLE
Fix expiresAfter tag

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -6,6 +6,9 @@ def type = "java"
 def product = "toffee"
 def component = "recipe-backend"
 
+// Stops sbox DBs being removed and blocking our builds
+def expiresAfter = "3000-01-01"
+
 static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
   [ $class: 'AzureKeyVaultSecret',
     secretType: 'Secret',

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -18,4 +18,6 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
   ]
 }
 
-withPipeline(type, product, component) {}
+withPipeline(type, product, component) {
+  expires(expiresAfter)
+}


### PR DESCRIPTION
This pipeline builds the toffee DB, which destroys every 2 weeks and when it does causes issues for our pipelines that are running health checks against plum in sbox. This change will stop it from expiring by updating the expiresAfter tag