### PR TITLE
Update ACR references from deprecated ones to hmctsprod and hmctssbox

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
  # renovate: datasource=github-releases depName=microsoft/ApplicationInsights-Java
 ARG APP_INSIGHTS_AGENT_VERSION=3.7.4
 ARG PLATFORM=""
-FROM hmctspublic.azurecr.io/base/java:21-distroless
+FROM hmctsprod.azurecr.io/base/java:21-distroless
 
 COPY build/libs/sds-toffee-recipes-service.jar /opt/app/
 

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -20,4 +20,8 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
 
 withPipeline(type, product, component) {
   expires(expiresAfter)
+
+  afterAlways('test') {
+      steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/problems/problems-report.html'
+  }
 }

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -24,5 +24,6 @@ withPipeline(type, product, component) {
   afterAlways('test') {
       steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/problems/problems-report.html'
       steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/tests/**/*'
+      steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/gatling/*'
   }
 }

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -22,8 +22,8 @@ withPipeline(type, product, component) {
   expires(expiresAfter)
 
   afterAlways('test') {
-      steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/problems/problems-report.html'
-      steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/tests/**/*'
-      steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/gatling/*'
+      // steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/problems/problems-report.html'
+      // steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/tests/**/*'
+      // steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/gatling/*'
   }
 }

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -23,5 +23,6 @@ withPipeline(type, product, component) {
 
   afterAlways('test') {
       steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/problems/problems-report.html'
+      steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/tests/**/*'
   }
 }

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -23,5 +23,6 @@ withNightlyPipeline(type, product, component) {
 
   afterAlways('test') {
       steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/problems/problems-report.html'
+      steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/tests/**/*'
   }
 }

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -22,8 +22,8 @@ withNightlyPipeline(type, product, component) {
   env.SecurityRules = params.SecurityRules
 
   afterAlways('test') {
-      steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/problems/problems-report.html'
-      steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/tests/**/*'
-      steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/gatling/*'
+      // steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/problems/problems-report.html'
+      // steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/tests/**/*'
+      // steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/gatling/*'
   }
 }

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -20,4 +20,8 @@ def component = "recipe-backend"
 withNightlyPipeline(type, product, component) {
   env.TEST_URL = params.URL_TO_TEST
   env.SecurityRules = params.SecurityRules
+
+  afterAlways('test') {
+      steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/problems/problems-report.html'
+  }
 }

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -24,5 +24,6 @@ withNightlyPipeline(type, product, component) {
   afterAlways('test') {
       steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/problems/problems-report.html'
       steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/tests/**/*'
+      steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/gatling/*'
   }
 }

--- a/Jenkinsfile_parameterized
+++ b/Jenkinsfile_parameterized
@@ -35,5 +35,6 @@ withParameterizedPipeline(params.TYPE, params.PRODUCT_NAME, params.APP, 'sbox', 
   afterAlways('test') {
       steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/problems/problems-report.html'
       steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/tests/**/*'
+      steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/gatling/*'
   }
 }

--- a/Jenkinsfile_parameterized
+++ b/Jenkinsfile_parameterized
@@ -34,5 +34,6 @@ withParameterizedPipeline(params.TYPE, params.PRODUCT_NAME, params.APP, 'sbox', 
 
   afterAlways('test') {
       steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/problems/problems-report.html'
+      steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/tests/**/*'
   }
 }

--- a/Jenkinsfile_parameterized
+++ b/Jenkinsfile_parameterized
@@ -31,4 +31,8 @@ env.KEEP_DIR_FOR_DEBUGGING = 'true'
 
 withParameterizedPipeline(params.TYPE, params.PRODUCT_NAME, params.APP, 'sbox', 'sbox') {
   expires(expiresAfter)
+
+  afterAlways('test') {
+      steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/problems/problems-report.html'
+  }
 }

--- a/Jenkinsfile_parameterized
+++ b/Jenkinsfile_parameterized
@@ -33,8 +33,8 @@ withParameterizedPipeline(params.TYPE, params.PRODUCT_NAME, params.APP, 'sbox', 
   expires(expiresAfter)
 
   afterAlways('test') {
-      steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/problems/problems-report.html'
-      steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/tests/**/*'
-      steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/gatling/*'
+      // steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/problems/problems-report.html'
+      // steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/tests/**/*'
+      // steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/gatling/*'
   }
 }

--- a/Jenkinsfile_pipeline_test
+++ b/Jenkinsfile_pipeline_test
@@ -36,12 +36,12 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
 withPipeline(type, product, app) {
   // never skip stages when testing the pipeline
   env.NO_SKIP_IMG_BUILD = 'true'
-  enablePerformanceTest()
+  // enablePerformanceTest()
   expires(expiresAfter)
 
-  afterAlways('test') {
-      steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/problems/problems-report.html'
-      steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/tests/**/*'
-      steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/gatling/*'
-  }
+  // afterAlways('test') {
+  //     steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/problems/problems-report.html'
+  //     steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/tests/**/*'
+  //     steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/gatling/*'
+  // }
 }

--- a/Jenkinsfile_pipeline_test
+++ b/Jenkinsfile_pipeline_test
@@ -40,8 +40,8 @@ withPipeline(type, product, app) {
   expires(expiresAfter)
 
   afterAlways('test') {
-      // steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/problems/problems-report.html'
-      // steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/tests/**/*'
-      // steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/gatling/*'
+      steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/problems/problems-report.html'
+      steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/tests/**/*'
+      steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/gatling/*'
   }
 }

--- a/Jenkinsfile_pipeline_test
+++ b/Jenkinsfile_pipeline_test
@@ -36,12 +36,12 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
 withPipeline(type, product, app) {
   // never skip stages when testing the pipeline
   env.NO_SKIP_IMG_BUILD = 'true'
-  // enablePerformanceTest()
+  enablePerformanceTest()
   expires(expiresAfter)
 
-  // afterAlways('test') {
-  //     steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/problems/problems-report.html'
-  //     steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/tests/**/*'
-  //     steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/gatling/*'
-  // }
+  afterAlways('test') {
+      steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/problems/problems-report.html'
+      steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/tests/**/*'
+      steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/gatling/*'
+  }
 }

--- a/Jenkinsfile_pipeline_test
+++ b/Jenkinsfile_pipeline_test
@@ -40,8 +40,8 @@ withPipeline(type, product, app) {
   expires(expiresAfter)
 
   afterAlways('test') {
-      steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/problems/problems-report.html'
-      steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/tests/**/*'
-      steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/gatling/*'
+      // steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/problems/problems-report.html'
+      // steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/tests/**/*'
+      // steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/gatling/*'
   }
 }

--- a/Jenkinsfile_pipeline_test
+++ b/Jenkinsfile_pipeline_test
@@ -38,4 +38,8 @@ withPipeline(type, product, app) {
   env.NO_SKIP_IMG_BUILD = 'true'
   enablePerformanceTest()
   expires(expiresAfter)
+
+  afterAlways('test') {
+      steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/problems/problems-report.html'
+  }
 }

--- a/Jenkinsfile_pipeline_test
+++ b/Jenkinsfile_pipeline_test
@@ -42,5 +42,6 @@ withPipeline(type, product, app) {
   afterAlways('test') {
       steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/problems/problems-report.html'
       steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/tests/**/*'
+      steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/gatling/*'
   }
 }

--- a/Jenkinsfile_pipeline_test
+++ b/Jenkinsfile_pipeline_test
@@ -41,5 +41,6 @@ withPipeline(type, product, app) {
 
   afterAlways('test') {
       steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/problems/problems-report.html'
+      steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/tests/**/*'
   }
 }

--- a/acb.tpl.yaml
+++ b/acb.tpl.yaml
@@ -1,7 +1,7 @@
 version: 1.0-preview-1
 steps:
   - id: pull-base-image-amd64
-    cmd: docker pull --platform linux/amd64 hmctspublic.azurecr.io/base/java:21-distroless && docker tag hmctspublic.azurecr.io/base/java:21-distroless hmctspublic.azurecr.io/base/java/linux/amd64:21-distroless
+    cmd: docker pull --platform linux/amd64 hmctsprod.azurecr.io/base/java:21-distroless && docker tag hmctsprod.azurecr.io/base/java:21-distroless hmctsprod.azurecr.io/base/java/linux/amd64:21-distroless
     when: ["-"]
     keep: true
 
@@ -16,7 +16,7 @@ steps:
     keep: true
 
   - id: pull-base-image-arm64
-    cmd: docker pull --platform linux/arm64 hmctspublic.azurecr.io/base/java:21-distroless && docker tag hmctspublic.azurecr.io/base/java:21-distroless hmctspublic.azurecr.io/base/java/linux/arm64:21-distroless
+    cmd: docker pull --platform linux/arm64 hmctsprod.azurecr.io/base/java:21-distroless && docker tag hmctsprod.azurecr.io/base/java:21-distroless hmctsprod.azurecr.io/base/java/linux/arm64:21-distroless
     when:
       - pull-base-image-amd64
     keep: true

--- a/build.gradle
+++ b/build.gradle
@@ -192,8 +192,8 @@ dependencies {
     exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
   }
   testImplementation group: 'com.typesafe', name: 'config', version: '1.4.4'
-  testImplementation "org.testcontainers:junit-jupiter:1.20.6"
-  testImplementation "org.testcontainers:postgresql:1.20.6"
+  testImplementation "org.testcontainers:junit-jupiter:1.21.4"
+  testImplementation "org.testcontainers:postgresql:1.21.4"
 }
 
 application {

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ plugins {
   id 'org.owasp.dependencycheck' version '12.1.3'
   id 'com.github.ben-manes.versions' version '0.52.0'
   id 'org.sonarqube' version '6.3.1.5724'
-  id 'io.gatling.gradle' version '3.14.3.6'
+  id 'io.gatling.gradle' version '3.14.9.2'
 }
 
 group = 'uk.gov.hmcts.reform'
@@ -170,6 +170,25 @@ configurations.all {
     eachDependency { DependencyResolveDetails details ->
       if (details.requested.group == 'ch.qos.logback') {
         details.useVersion '1.4.14'
+      }
+    }
+  }
+}
+
+/* Spring's and Gatling's dependencies clash as they both live within the same Gradle module
+   Both are using io.netty and it is possible for Spring to overwrite it to a version to lower/different to what Gatling wants or vice versa
+   This can cause an issue such as: Caused by: java.lang.ClassNotFoundException: io.netty.channel.IoHandle when these two diverge
+   Issue: https://community.gatling.io/t/java-lang-noclassdeffounderror-io-netty-channel-iohandle/9672/4
+*/
+configurations.matching { it.name.toLowerCase().contains('gatling') }.all {
+  resolutionStrategy {
+    eachDependency { DependencyResolveDetails details ->
+      if (details.requested.group == 'io.netty') {
+        if (details.requested.name.startsWith('netty-tcnative')) {
+          details.useVersion '2.0.71.Final'
+        } else {
+          details.useVersion '4.2.1.Final'
+        }
       }
     }
   }

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,8 @@ checkstyle {
 
 ext {
   lombokVersion = '1.18.38'
+  // Force this version to fix issue: https://github.com/testcontainers/testcontainers-java/issues/11212
+  testcontainersVersion = '1.21.4'
 }
 
 testing {
@@ -113,6 +115,10 @@ repositories {
 }
 
 dependencyManagement {
+  imports {
+    mavenBom "org.testcontainers:testcontainers-bom:${testcontainersVersion}"
+  }
+
     dependencies {
 
         //CVE-2022-25857, CVE-2022-38749, CVE-2022-38750, CVE-2022-38751, CVE-2022-38752, CVE-2022-41854
@@ -192,8 +198,8 @@ dependencies {
     exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
   }
   testImplementation group: 'com.typesafe', name: 'config', version: '1.4.4'
-  testImplementation "org.testcontainers:junit-jupiter:1.21.4"
-  testImplementation "org.testcontainers:postgresql:1.21.4"
+  testImplementation "org.testcontainers:junit-jupiter:${testcontainersVersion}"
+  testImplementation "org.testcontainers:postgresql:${testcontainersVersion}"
 }
 
 application {

--- a/build.gradle
+++ b/build.gradle
@@ -187,7 +187,7 @@ dependencies {
 
   implementation group: 'com.google.guava', name: 'guava', version: '33.4.8-jre'
 
-  implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '6.1.9'
+  implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '8.0.0'
   implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.6.0'
 
   compileOnly group: 'org.projectlombok', name: 'lombok', version: lombokVersion

--- a/charts/apple-recipe-backend/Chart.yaml
+++ b/charts/apple-recipe-backend/Chart.yaml
@@ -8,4 +8,4 @@ maintainers:
 dependencies:
   - name: java
     version: 5.3.0
-    repository: oci://hmctspublic.azurecr.io/helm
+    repository: oci://hmctsprod.azurecr.io/helm

--- a/charts/apple-recipe-backend/Chart.yaml
+++ b/charts/apple-recipe-backend/Chart.yaml
@@ -1,7 +1,7 @@
 name: apple-recipe-backend
 apiVersion: v2
 home: https://github.com/hmcts/sds-toffee-recipes-service
-version: 0.2.23
+version: 0.2.24
 description: This is for Jenkins pipeline tests of toffee /apple app.
 maintainers:
   - name: HMCTS Platform Operations Team

--- a/charts/apple-recipe-backend/values.yaml
+++ b/charts/apple-recipe-backend/values.yaml
@@ -1,6 +1,6 @@
 java:
   applicationPort: 4550
-  image: 'hmctssandbox.azurecr.io/hmcts/apple-recipe-backend:latest'
+  image: 'hmctssbox.azurecr.io/hmcts/apple-recipe-backend:latest'
   environment:
     POSTGRES_SSL_MODE: require
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: /mnt/secrets/applesi/app-insights-config

--- a/charts/toffee-recipe-backend/Chart.yaml
+++ b/charts/toffee-recipe-backend/Chart.yaml
@@ -8,4 +8,4 @@ maintainers:
 dependencies:
   - name: java
     version: 5.3.0
-    repository: oci://hmctspublic.azurecr.io/helm
+    repository: oci://hmctsprod.azurecr.io/helm

--- a/charts/toffee-recipe-backend/Chart.yaml
+++ b/charts/toffee-recipe-backend/Chart.yaml
@@ -1,7 +1,7 @@
 name: toffee-recipe-backend
 apiVersion: v2
 home: https://github.com/hmcts/sds-toffee-recipes-service
-version: 0.8.39
+version: 0.8.40
 description: HMCTS toffee recipes service (test application)
 maintainers:
   - name: HMCTS Platform Operations Team

--- a/charts/toffee-recipe-backend/values.yaml
+++ b/charts/toffee-recipe-backend/values.yaml
@@ -2,7 +2,7 @@ java:
   applicationPort: 4550
   readinessPath: '/health/readiness'
   # Don't modify below here
-  image: 'sdshmctspublic.azurecr.io/toffee/recipe-backend:latest'
+  image: 'hmctsprod.azurecr.io/toffee/recipe-backend:latest'
   environment:
     POSTGRES_SSL_MODE: require
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: /mnt/secrets/toffeesi/app-insights-config


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-30785

### Change description
I wanted to rebuild sds-toffee just to get some fresh cve reporting but it looks like both SDS apps are failing due to ACR migrations not having been done.

### Testing done
N/A

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
