### PR TITLE
DTSPO-31128: Lower crit rating for toffee sbox DB to un-enroll backups

### DIFF
--- a/infrastructure/sbox.tfvars
+++ b/infrastructure/sbox.tfvars
@@ -1,5 +1,4 @@
 api_gateway_test_certificate_thumbprint = "4A98AB1CFFBA46CACBC7D8D3E10FDA667261DFAA"
 pgsql_sku                               = "B_Standard_B1ms"
-service_criticality                     = 4
 asp_sku_size                            = "B1"
 asp_capacity                            = 1


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-31128

### Change description

- Testing of PostgreSQL DB backups to Backup Vault is now complete
- Remove criticality 4 for sbox DB so no longer backed up, this was just used for testing purposes
- Allows recreation of Backup Vault to be backed by standard GRS SA now cross-region restore is not a requirement

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
