### PR TITLE
Update all old ACR references to new versions i.e. hmctsprod and hmctssbox

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
  # renovate: datasource=github-releases depName=microsoft/ApplicationInsights-Java
 ARG APP_INSIGHTS_AGENT_VERSION=3.7.4
 ARG PLATFORM=""
-FROM hmctspublic.azurecr.io/base/java:21-distroless
+FROM hmctsprod.azurecr.io/base/java:21-distroless
 
 COPY build/libs/sds-toffee-recipes-service.jar /opt/app/
 

--- a/acb.tpl.yaml
+++ b/acb.tpl.yaml
@@ -1,7 +1,7 @@
 version: 1.0-preview-1
 steps:
   - id: pull-base-image-amd64
-    cmd: docker pull --platform linux/amd64 hmctspublic.azurecr.io/base/java:21-distroless && docker tag hmctspublic.azurecr.io/base/java:21-distroless hmctspublic.azurecr.io/base/java/linux/amd64:21-distroless
+    cmd: docker pull --platform linux/amd64 hmctsprod.azurecr.io/base/java:21-distroless && docker tag hmctsprod.azurecr.io/base/java:21-distroless hmctsprod.azurecr.io/base/java/linux/amd64:21-distroless
     when: ["-"]
     keep: true
 
@@ -16,7 +16,7 @@ steps:
     keep: true
 
   - id: pull-base-image-arm64
-    cmd: docker pull --platform linux/arm64 hmctspublic.azurecr.io/base/java:21-distroless && docker tag hmctspublic.azurecr.io/base/java:21-distroless hmctspublic.azurecr.io/base/java/linux/arm64:21-distroless
+    cmd: docker pull --platform linux/arm64 hmctsprod.azurecr.io/base/java:21-distroless && docker tag hmctsprod.azurecr.io/base/java:21-distroless hmctsprod.azurecr.io/base/java/linux/arm64:21-distroless
     when:
       - pull-base-image-amd64
     keep: true

--- a/build.gradle
+++ b/build.gradle
@@ -192,8 +192,8 @@ dependencies {
     exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
   }
   testImplementation group: 'com.typesafe', name: 'config', version: '1.4.4'
-  testImplementation "org.testcontainers:junit-jupiter:1.20.6"
-  testImplementation "org.testcontainers:postgresql:1.20.6"
+  testImplementation "org.testcontainers:junit-jupiter:1.21.4"
+  testImplementation "org.testcontainers:postgresql:1.21.4"
 }
 
 application {

--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,7 @@ dependencyManagement {
     imports {
       mavenBom "org.testcontainers:testcontainers-bom:1.21.4"
     }
+
     dependencies {
 
         //CVE-2022-25857, CVE-2022-38749, CVE-2022-38750, CVE-2022-38751, CVE-2022-38752, CVE-2022-41854
@@ -166,9 +167,23 @@ dependencyUpdates {
 configurations.all {
   resolutionStrategy {
     eachDependency { DependencyResolveDetails details ->
-
       if (details.requested.group == 'ch.qos.logback') {
         details.useVersion '1.4.14'
+      }
+    }
+  }
+}
+
+/* Spring Boot and Gatling clash on the Netty dependency and the Gradle resolution picks the Spring Boot's 4.1.109.Final 
+   Gradle requires 4.2.1.Final for the tests to run, so we need to force it to use that version for the Gatling tests 
+   With the exception of netty-tcnative which does not have a 4.2.1.Final version
+   https://community.gatling.io/t/java-lang-noclassdeffounderror-io-netty-channel-iohandle/9672
+   */
+configurations.matching { it.name.toLowerCase().contains('gatling') }.all {
+  resolutionStrategy {
+    eachDependency { DependencyResolveDetails details ->
+      if (details.requested.group == 'io.netty' && !details.requested.name.startsWith('netty-tcnative')) {
+        details.useVersion '4.2.1.Final'
       }
     }
   }

--- a/build.gradle
+++ b/build.gradle
@@ -193,7 +193,7 @@ dependencies {
   }
   testImplementation group: 'com.typesafe', name: 'config', version: '1.4.4'
   testImplementation "org.testcontainers:junit-jupiter:1.21.4"
-  testImplementation "org.testcontainers:postgresql:1.21.4"
+  testImplementation "org.testcontainers:postgresql"
 }
 
 application {

--- a/build.gradle
+++ b/build.gradle
@@ -113,10 +113,10 @@ repositories {
 }
 
 dependencyManagement {
-    // // Ensure TestContainers versions 1.21.4 are used instead of 1.19.7 set by Spring Boot BOM
-    // imports {
-    //   mavenBom "org.testcontainers:testcontainers-bom:1.21.4"
-    // }
+    // Ensure TestContainers versions 1.21.4 are used instead of 1.19.7 set by Spring Boot
+    imports {
+      mavenBom "org.testcontainers:testcontainers-bom:1.21.4"
+    }
     dependencies {
 
         //CVE-2022-25857, CVE-2022-38749, CVE-2022-38750, CVE-2022-38751, CVE-2022-38752, CVE-2022-41854
@@ -198,9 +198,6 @@ dependencies {
   }
   testImplementation group: 'com.typesafe', name: 'config', version: '1.4.4'
 
-  /* Spring Boot's BOM normally overrides these versions back to 1.19.7 which fails to connect to Docker in the pipeline
-     so ensure that these do not get override by adding the 1.21.4 TestContainers BOM */
-  testImplementation platform("org.testcontainers:testcontainers-bom:1.21.4")
   testImplementation "org.testcontainers:junit-jupiter"
   testImplementation "org.testcontainers:postgresql"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -193,7 +193,7 @@ dependencies {
   }
   testImplementation group: 'com.typesafe', name: 'config', version: '1.4.4'
   testImplementation "org.testcontainers:junit-jupiter:1.21.4"
-  testImplementation "org.testcontainers:postgresql"
+  testImplementation "org.testcontainers:postgresql:1.21.4"
 }
 
 application {

--- a/build.gradle
+++ b/build.gradle
@@ -113,6 +113,10 @@ repositories {
 }
 
 dependencyManagement {
+    // // Ensure TestContainers versions 1.21.4 are used instead of 1.19.7 set by Spring Boot BOM
+    // imports {
+    //   mavenBom "org.testcontainers:testcontainers-bom:1.21.4"
+    // }
     dependencies {
 
         //CVE-2022-25857, CVE-2022-38749, CVE-2022-38750, CVE-2022-38751, CVE-2022-38752, CVE-2022-41854
@@ -162,9 +166,7 @@ dependencyUpdates {
 configurations.all {
   resolutionStrategy {
     eachDependency { DependencyResolveDetails details ->
-      if (details.requested.group == 'org.testcontainers') {
-        details.useVersion '1.21.4'
-      }
+
       if (details.requested.group == 'ch.qos.logback') {
         details.useVersion '1.4.14'
       }
@@ -195,8 +197,12 @@ dependencies {
     exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
   }
   testImplementation group: 'com.typesafe', name: 'config', version: '1.4.4'
-  testImplementation "org.testcontainers:junit-jupiter:1.21.4"
-  testImplementation "org.testcontainers:postgresql:1.21.4"
+
+  /* Spring Boot's BOM normally overrides these versions back to 1.19.7 which fails to connect to Docker in the pipeline
+     so ensure that these do not get override by adding the 1.21.4 TestContainers BOM */
+  testImplementation platform("org.testcontainers:testcontainers-bom:1.21.4")
+  testImplementation "org.testcontainers:junit-jupiter"
+  testImplementation "org.testcontainers:postgresql"
 }
 
 application {

--- a/build.gradle
+++ b/build.gradle
@@ -162,6 +162,9 @@ dependencyUpdates {
 configurations.all {
   resolutionStrategy {
     eachDependency { DependencyResolveDetails details ->
+      if (details.requested.group == 'org.testcontainers') {
+        details.useVersion '1.21.4'
+      }
       if (details.requested.group == 'ch.qos.logback') {
         details.useVersion '1.4.14'
       }

--- a/charts/apple-recipe-backend/Chart.yaml
+++ b/charts/apple-recipe-backend/Chart.yaml
@@ -8,4 +8,4 @@ maintainers:
 dependencies:
   - name: java
     version: 5.3.0
-    repository: oci://hmctspublic.azurecr.io/helm
+    repository: oci://hmctsprod.azurecr.io/helm

--- a/charts/apple-recipe-backend/Chart.yaml
+++ b/charts/apple-recipe-backend/Chart.yaml
@@ -1,7 +1,7 @@
 name: apple-recipe-backend
 apiVersion: v2
 home: https://github.com/hmcts/sds-toffee-recipes-service
-version: 0.2.23
+version: 0.2.24
 description: This is for Jenkins pipeline tests of toffee /apple app.
 maintainers:
   - name: HMCTS Platform Operations Team

--- a/charts/apple-recipe-backend/values.yaml
+++ b/charts/apple-recipe-backend/values.yaml
@@ -1,6 +1,6 @@
 java:
   applicationPort: 4550
-  image: 'hmctssandbox.azurecr.io/hmcts/apple-recipe-backend:latest'
+  image: 'hmctssbox.azurecr.io/hmcts/apple-recipe-backend:latest'
   environment:
     POSTGRES_SSL_MODE: require
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: /mnt/secrets/applesi/app-insights-config

--- a/charts/toffee-recipe-backend/Chart.yaml
+++ b/charts/toffee-recipe-backend/Chart.yaml
@@ -8,4 +8,4 @@ maintainers:
 dependencies:
   - name: java
     version: 5.3.0
-    repository: oci://hmctspublic.azurecr.io/helm
+    repository: oci://hmctsprod.azurecr.io/helm

--- a/charts/toffee-recipe-backend/Chart.yaml
+++ b/charts/toffee-recipe-backend/Chart.yaml
@@ -1,7 +1,7 @@
 name: toffee-recipe-backend
 apiVersion: v2
 home: https://github.com/hmcts/sds-toffee-recipes-service
-version: 0.8.39
+version: 0.8.40
 description: HMCTS toffee recipes service (test application)
 maintainers:
   - name: HMCTS Platform Operations Team

--- a/charts/toffee-recipe-backend/values.yaml
+++ b/charts/toffee-recipe-backend/values.yaml
@@ -2,7 +2,7 @@ java:
   applicationPort: 4550
   readinessPath: '/health/readiness'
   # Don't modify below here
-  image: 'sdshmctspublic.azurecr.io/toffee/recipe-backend:latest'
+  image: 'hmctsprod.azurecr.io/toffee/recipe-backend:latest'
   environment:
     POSTGRES_SSL_MODE: require
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: /mnt/secrets/toffeesi/app-insights-config


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-32159
Just triggering the build to double check all is ok after patching: https://github.com/hmcts/sds-flux-config/pull/8418

### Change description

Update all references to old ACR to fix the build and also get the Master branch back into Jenkins as it has been cleaned up due to lack of commits by the aged references plugin.

### Testing done

-

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [ ] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
