### PR TITLE
Remove backup enrollment criticality of 4 from SDS sbox as this appears to have been set for testing

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -100,8 +100,6 @@ module "postgresql_flexible" {
 
   pgsql_version = "15"
   pgsql_sku     = var.pgsql_sku
-
-  service_criticality = var.service_criticality
 }
 
 module "app_service_plan" {

--- a/infrastructure/sbox.tfvars
+++ b/infrastructure/sbox.tfvars
@@ -1,5 +1,4 @@
 api_gateway_test_certificate_thumbprint = "4A98AB1CFFBA46CACBC7D8D3E10FDA667261DFAA"
 pgsql_sku                               = "B_Standard_B1ms"
-service_criticality                     = 4
 asp_sku_size                            = "B1"
 asp_capacity                            = 1

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -48,12 +48,6 @@ variable "pgsql_sku" {
   default = "GP_Standard_D2s_v3"
 }
 
-variable "service_criticality" {
-  description = "Service criticality rating from 1-5."
-  type        = number
-  default     = 1
-}
-
 variable "asp_sku_size" {
   type        = string
   description = "SKU size for the App Service Plan (e.g. B1, P1v3)."


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-32159

### Change description

Remove high criticality setting from sbox TF config.
This setting causes the flex postgres module to try create a backup instance within cnp-backup-vault in prod subscription which fails likely due to environment mismatch as this is a sandbox resource, we probably don't want to keep backup instance of SDS Sandbox anyway.
I believe this was done as part of testing during implementation of this feature and then forgotten about as I can see that the CNP side has been cleaned up.

Error:
```
[2026-05-14T13:58:59.764Z] │ Error: creating Backup Instance (Subscription: "8999dec3-0104-4a27-94ee-6588559729d1"
[2026-05-14T13:58:59.764Z] │ Resource Group Name: "mgmt-infra-prod-rg"
[2026-05-14T13:58:59.764Z] │ Backup Vault Name: "cnp-backup-vault"
[2026-05-14T13:58:59.764Z] │ Backup Instance Name: "apple-v14-flexible-sbox-backup-instance"): performing CreateOrUpdate: unexpected status 406 (406 Not Acceptable) received with no body
[2026-05-14T13:58:59.764Z] │ 
[2026-05-14T13:58:59.764Z] │   with module.postgresql_flexible.azurerm_data_protection_backup_instance_postgresql_flexible_server.main[0],
[2026-05-14T13:58:59.764Z] │   on .terraform/modules/postgresql_flexible/backup.tf line 31, in resource "azurerm_data_protection_backup_instance_postgresql_flexible_server" "main":
[2026-05-14T13:58:59.764Z] │   31: resource "azurerm_data_protection_backup_instance_postgresql_flexible_server" "main" {
[2026-05-14T13:58:59.764Z] │ 
[2026-05-14T13:58:59.764Z] │ creating Backup Instance (Subscription:
[2026-05-14T13:58:59.764Z] │ "8999dec3-0104-4a27-94ee-6588559729d1"
[2026-05-14T13:58:59.764Z] │ Resource Group Name: "mgmt-infra-prod-rg"
[2026-05-14T13:58:59.764Z] │ Backup Vault Name: "cnp-backup-vault"
[2026-05-14T13:58:59.765Z] │ Backup Instance Name: "apple-v14-flexible-sbox-backup-instance"):
[2026-05-14T13:58:59.765Z] │ performing CreateOrUpdate: unexpected status 406 (406 Not Acceptable)
[2026-05-14T13:58:59.765Z] │ received with no body
```

Some references:
- https://github.com/hmcts/terraform-module-postgresql-flexible/commit/669d8e45ad65286980e3bc64bfef2aea52be84a6
- https://github.com/hmcts/cnp-plum-recipes-service/commit/63e5ebe279acb0488e5d18e3375eb71f5a5a466a
- https://tools.hmcts.net/jira/browse/DTSPO-29356

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behaviour remains the same.
-->

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [ ] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
