### PR TITLE
Update Jenkins library to 2.2.0

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,6 +1,6 @@
 #!groovy
 
-@Library("Infrastructure") _
+@Library("Infrastructure@2.2.0") _
 
 def type = "java"
 def product = "toffee"

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -11,7 +11,7 @@ properties([
       ])
 ])
 
-@Library("Infrastructure")
+@Library("Infrastructure@2.2.0")
 
 def type = "java"
 def product = "toffee"

--- a/build.gradle
+++ b/build.gradle
@@ -201,7 +201,7 @@ dependencies {
 
   implementation group: 'com.google.guava', name: 'guava', version: '33.4.8-jre'
 
-  implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '6.1.9'
+  implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '8.0.0'
   implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.6.0'
 
   compileOnly group: 'org.projectlombok', name: 'lombok', version: lombokVersion


### PR DESCRIPTION
Updates Jenkinsfiles to use `Infrastructure@2.2.0` so the pipeline can be validated against the fixed env-agent rollout tag.

No application code changes.
