### PR TITLE
Add renovate preset for cnp jenkins library updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,22 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
+    "github>hmcts/.github//renovate/cnp-jenkins-library",
     "github>hmcts/.github//renovate/automerge-all",
     "local>hmcts/.github:renovate-config"
+  ],
+  "packageRules": [
+    {
+      "matchPackagePatterns": ["Jenkins-.*"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "automergeType": "pr"
+    },
+    {
+      "matchPackagePatterns": ["Jenkins-.*"],
+      "matchUpdateTypes": ["major"],
+      "automerge": false,
+      "platformAutomerge": false
+    }
   ]
 }

--- a/Jenkinsfile_pipeline_test
+++ b/Jenkinsfile_pipeline_test
@@ -36,7 +36,6 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
 withPipeline(type, product, app) {
   // never skip stages when testing the pipeline
   env.NO_SKIP_IMG_BUILD = 'true'
-  enableBuildCache()
   enablePerformanceTest()
   expires(expiresAfter)
 }


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-33852

### Change description

Add renovate preset for cnp jenkins library.
[This is working correctly in sds toffee frontend](https://github.com/hmcts/sds-toffee-frontend/pull/779) so adding this in this java repository as a last check before announcing to teams.

### Testing done

This configuration has worked successfuly in [sds-toffee-frontent](https://github.com/hmcts/sds-toffee-frontend/pull/779).

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
