### PR TITLE
Set CNP Jenkins Library version in the Jenkinsfiles to semver tagged version so Renovate is able to compare it to latest

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,6 +1,6 @@
 #!groovy
 
-@Library("Infrastructure@DTSPO-30107-jenkins-agents-2") _
+@Library("Infrastructure@2.4.9") _
 
 def type = "java"
 def product = "toffee"

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -11,7 +11,7 @@ properties([
       ])
 ])
 
-@Library("Infrastructure")
+@Library("Infrastructure@2.4.9")
 
 def type = "java"
 def product = "toffee"


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-33852

### Change description

Can see that Renovate has picked the jenkins lib dep up but because its set to a branch it is not able to actually compare to latest version so it did nothing:

```
    "regex": [
      {
        "deps": [
          {
            "depName": "Jenkins-Infrastructure",
            "packageName": "hmcts/cnp-jenkins-library",
            "currentValue": "DTSPO-30107-jenkins-agents-2",
            "datasource": "github-tags",
            "versioning": "semver",
            "replaceString": "@Library(\"Infrastructure@DTSPO-30107-jenkins-agents-2\")",
            "updates": [],
            "warnings": [],
            "skipReason": "invalid-value"
          }
```

### Testing done

Everything seems to work ok, just want to sort this fully so PR gets created and update merged.

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
